### PR TITLE
Fix for gcc 8

### DIFF
--- a/source/include/gch/small_vector.hpp
+++ b/source/include/gch/small_vector.hpp
@@ -1401,7 +1401,9 @@ namespace gch
       GCH_CPP20_CONSTEXPR
       void
       maybe_assign (allocator_inliner&& other)
+#if defined(__clang__) || ! defined(__GNUC__) || __GNUC__>=9
       noexcept (noexcept (Allocator::operator= (std::move (other))))
+#endif
       {
         Allocator::operator= (std::move (other));
       }


### PR DESCRIPTION
@gharveymn thanks a lot for sharing this!

I am checking if it's possible to use your library in [our code](https://github.com/plumed/plumed2/pull/1015/commits/db959a39eb60d8bd653cfd29c3864e5938577a39). I however found  an issue with gcc 8, that I addressed [here](https://github.com/plumed/plumed2/pull/1015/commits/7168aa1ca50e75eb5986e708018264d9c0af57db). You can see the problem here:
https://wandbox.org/permlink/KcUf2IWF7yOJ1UKo

Can you confirm that the solution is correct? As far as I understand, this would only impact performance on gcc 8 and not correctness.

You might also want to merge this pull request to include the fix in the main branch.

Thanks again!