### PR TITLE
Fix allocator construction tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.15)
 project (
   small_vector
   VERSION
-    0.9.2
+    0.10.0
   LANGUAGES
     CXX
 )

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import os
 class GchSmallVectorConan(ConanFile):
     name = "small_vector"
     author = "Gene Harvey <gharveymn@gmail.com>"
-    version = "0.9.2"
+    version = "0.10.0"
     license = "MIT"
     url = "https://github.com/gharveymn/small_vector"
     description = "A fully featured single header library implementing a vector container with a small buffer optimization."

--- a/source/test/unit/main.cpp
+++ b/source/test/unit/main.cpp
@@ -6,7 +6,6 @@
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #include "unit_test_common.hpp"
-#include "test_allocators.hpp"
 
 int
 main (void)

--- a/source/test/unit/member/assign/test-copy.cpp
+++ b/source/test/unit/member/assign/test-copy.cpp
@@ -199,6 +199,9 @@ private:
   void
   check (vector_init_type<N> ni, vector_init_type<M> mi)
   {
+    constexpr bool
+    propagate = std::allocator_traits<Allocator>::propagate_on_container_copy_assignment::value;
+
     vector_type<N> n_cmp (ni.begin (), ni.end (), m_lhs_alloc);
     vector_type<M> m_cmp (mi.begin (), mi.end (), m_rhs_alloc);
     {
@@ -212,6 +215,9 @@ private:
       n.assign (m);
       CHECK (n == m_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (n.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (n.get_allocator () == m_rhs_alloc));
+
     }
     {
       // vector_type<N> (ni) -> vector_type<M> (mi)
@@ -224,6 +230,8 @@ private:
       m.assign (n);
       CHECK (m == n_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (m.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (m.get_allocator () == m_lhs_alloc));
     }
     {
       // vector_type<M> (ni) -> vector_type<N> (mi)
@@ -236,6 +244,8 @@ private:
       n.assign (m);
       CHECK (n == n_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (n.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (n.get_allocator () == m_rhs_alloc));
     }
     {
       // vector_type<N> (mi) -> vector_type<M> (ni)
@@ -248,6 +258,8 @@ private:
       m.assign (n);
       CHECK (m == m_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (m.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (m.get_allocator () == m_lhs_alloc));
     }
   }
 
@@ -259,18 +271,5 @@ GCH_SMALL_VECTOR_TEST_CONSTEXPR
 int
 test (void)
 {
-  using namespace gch::test_types;
-
-  test_with_allocator<tester, std::allocator> ();
-  test_with_allocator<tester, sized_allocator, std::uint8_t> ();
-  test_with_allocator<tester, fancy_pointer_allocator> ();
-  test_with_allocator<tester, allocator_with_id> ();
-  test_with_allocator<tester, propagating_allocator_with_id> ();
-
-#ifndef GCH_SMALL_VECTOR_TEST_HAS_CONSTEXPR
-  test_with_allocator<tester, verifying_allocator> ();
-  test_with_allocator<tester, non_propagating_verifying_allocator> ();
-#endif
-
-  return 0;
+  return test_with_allocators<tester> ();
 }

--- a/source/test/unit/member/assign/test-move.cpp
+++ b/source/test/unit/member/assign/test-move.cpp
@@ -95,114 +95,6 @@ struct tester
       { { 1, 2, 3, 4, 5 }, m_reserver },
     };
 
-    check (ns[0], ms[0]);
-    check (ns[0], ms[1]);
-    check (ns[0], ms[2]);
-    check (ns[0], ms[3]);
-    check (ns[0], ms[4]);
-    check (ns[0], ms[5]);
-    check (ns[0], ms[6]);
-    check (ns[0], ms[7]);
-    check (ns[0], ms[8]);
-    check (ns[0], ms[9]);
-    check (ns[0], ms[10]);
-
-    check (ns[1], ms[0]);
-    check (ns[1], ms[1]);
-    check (ns[1], ms[2]);
-    check (ns[1], ms[3]);
-    check (ns[1], ms[4]);
-    check (ns[1], ms[5]);
-    check (ns[1], ms[6]);
-    check (ns[1], ms[7]);
-    check (ns[1], ms[8]);
-    check (ns[1], ms[9]);
-    check (ns[1], ms[10]);
-
-    check (ns[2], ms[0]);
-    check (ns[2], ms[1]);
-    check (ns[2], ms[2]);
-    check (ns[2], ms[3]);
-    check (ns[2], ms[4]);
-    check (ns[2], ms[5]);
-    check (ns[2], ms[6]);
-    check (ns[2], ms[7]);
-    check (ns[2], ms[8]);
-    check (ns[2], ms[9]);
-    check (ns[2], ms[10]);
-
-    check (ns[3], ms[0]);
-    check (ns[3], ms[1]);
-    check (ns[3], ms[2]);
-    check (ns[3], ms[3]);
-    check (ns[3], ms[4]);
-    check (ns[3], ms[5]);
-    check (ns[3], ms[6]);
-    check (ns[3], ms[7]);
-    check (ns[3], ms[8]);
-    check (ns[3], ms[9]);
-    check (ns[3], ms[10]);
-
-    check (ns[4], ms[0]);
-    check (ns[4], ms[1]);
-    check (ns[4], ms[2]);
-    check (ns[4], ms[3]);
-    check (ns[4], ms[4]);
-    check (ns[4], ms[5]);
-    check (ns[4], ms[6]);
-    check (ns[4], ms[7]);
-    check (ns[4], ms[8]);
-    check (ns[4], ms[9]);
-    check (ns[4], ms[10]);
-
-    check (ns[5], ms[0]);
-    check (ns[5], ms[1]);
-    check (ns[5], ms[2]);
-    check (ns[5], ms[3]);
-    check (ns[5], ms[4]);
-    check (ns[5], ms[5]);
-    check (ns[5], ms[6]);
-    check (ns[5], ms[7]);
-    check (ns[5], ms[8]);
-    check (ns[5], ms[9]);
-    check (ns[5], ms[10]);
-
-    check (ns[6], ms[0]);
-    check (ns[6], ms[1]);
-    check (ns[6], ms[2]);
-    check (ns[6], ms[3]);
-    check (ns[6], ms[4]);
-    check (ns[6], ms[5]);
-    check (ns[6], ms[6]);
-    check (ns[6], ms[7]);
-    check (ns[6], ms[8]);
-    check (ns[6], ms[9]);
-    check (ns[6], ms[10]);
-
-    check (ns[7], ms[0]);
-    check (ns[7], ms[1]);
-    check (ns[7], ms[2]);
-    check (ns[7], ms[3]);
-    check (ns[7], ms[4]);
-    check (ns[7], ms[5]);
-    check (ns[7], ms[6]);
-    check (ns[7], ms[7]);
-    check (ns[7], ms[8]);
-    check (ns[7], ms[9]);
-    check (ns[7], ms[10]);
-
-    check (ns[8], ms[0]);
-    check (ns[8], ms[1]);
-    check (ns[8], ms[2]);
-    check (ns[8], ms[3]);
-    check (ns[8], ms[4]);
-    check (ns[8], ms[5]);
-    check (ns[8], ms[6]);
-    check (ns[8], ms[7]);
-    check (ns[8], ms[8]);
-    check (ns[8], ms[9]);
-    check (ns[8], ms[10]);
-
     for (std::size_t i = 0; i < ns.size (); ++i)
       for (std::size_t j = 0; j < ms.size (); ++j)
         check (ns[i], ms[j]);
@@ -306,6 +198,9 @@ private:
   void
   check (vector_init_type<N> ni, vector_init_type<M> mi)
   {
+    constexpr bool
+    propagate = std::allocator_traits<Allocator>::propagate_on_container_move_assignment::value;
+
     vector_type<N> n_cmp (ni.begin (), ni.end (), m_lhs_alloc);
     vector_type<M> m_cmp (mi.begin (), mi.end (), m_rhs_alloc);
     {
@@ -319,6 +214,8 @@ private:
       n.assign (std::move (m));
       CHECK (n == m_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (n.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (n.get_allocator () == m_rhs_alloc));
     }
     {
       // vector_type<N> (ni) -> vector_type<M> (mi)
@@ -331,6 +228,8 @@ private:
       m.assign (std::move (n));
       CHECK (m == n_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (m.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (m.get_allocator () == m_lhs_alloc));
     }
     {
       // vector_type<M> (ni) -> vector_type<N> (mi)
@@ -343,6 +242,8 @@ private:
       n.assign (std::move (m));
       CHECK (n == n_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (n.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (n.get_allocator () == m_rhs_alloc));
     }
     {
       // vector_type<N> (mi) -> vector_type<M> (ni)
@@ -355,6 +256,8 @@ private:
       m.assign (std::move (n));
       CHECK (m == m_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (m.get_allocator ());
+      if (m_lhs_alloc != m_rhs_alloc)
+        CHECK (propagate == (m.get_allocator () == m_lhs_alloc));
     }
   }
 
@@ -366,18 +269,5 @@ GCH_SMALL_VECTOR_TEST_CONSTEXPR
 int
 test (void)
 {
-  using namespace gch::test_types;
-
-  test_with_allocator<tester, std::allocator> ();
-  test_with_allocator<tester, sized_allocator, std::uint8_t> ();
-  test_with_allocator<tester, fancy_pointer_allocator> ();
-  test_with_allocator<tester, allocator_with_id> ();
-  test_with_allocator<tester, propagating_allocator_with_id> ();
-
-#ifndef GCH_SMALL_VECTOR_TEST_HAS_CONSTEXPR
-  test_with_allocator<tester, verifying_allocator> ();
-  test_with_allocator<tester, non_propagating_verifying_allocator> ();
-#endif
-
-  return 0;
+  return test_with_allocators<tester> ();
 }

--- a/source/test/unit/member/swap/test.cpp
+++ b/source/test/unit/member/swap/test.cpp
@@ -31,16 +31,97 @@ struct tester
   int
   operator() (void)
   {
-    check_with_inline_capacity<2> ();
-    check_with_inline_capacity<0> ();
+    check_unequal_inline ();
+    check_no_inline ();
+    check_equal_inline ();
+
     return 0;
   }
 
 private:
-  template <unsigned N>
   GCH_SMALL_VECTOR_TEST_CONSTEXPR
-  void
-  check_with_inline_capacity (void)
+  int
+  check_unequal_inline (void)
+  {
+    // Check vectors with the same number of inline elements.
+    // Let N = 3, M = 5.
+    // States to check:
+    //   Combinations of (with repeats):
+    //     Inlined:
+    //       0 == K elements.    (1)
+    //       K < N elements.     (2)
+    //       N == K elements.    (3)
+    //       N < K < M elements. (4) (only for M)
+    //       M == K elements.    (5) (only for M)
+    //     Allocated:
+    //       0 == K elements.    (7)
+    //       K < N elements.     (8)
+    //       N == K elements.    (9)
+    //       N < K < M elements. (10)
+    //       M == K elements.    (11)
+    //       M < K elements.     (12)
+    //   for M and N (99 total cases).
+
+    auto n_reserver = [](vector_type<2>& v) {
+      v.reserve (3);
+    };
+
+    auto m_reserver = [](vector_type<4>& v) {
+      v.reserve (5);
+    };
+
+    std::array<vector_init_type<2>, 9> ns {
+      vector_init_type<2> { },
+      { 1 },
+      { 1, 2 },
+      { { },               n_reserver },
+      { { 1 },             n_reserver },
+      { { 1, 2 },          n_reserver },
+      { { 1, 2, 3 },       n_reserver },
+      { { 1, 2, 3, 4 },    n_reserver },
+      { { 1, 2, 3, 4, 5 }, n_reserver },
+    };
+
+    std::array<vector_init_type<4>, 11> ms {
+      vector_init_type<4> { },
+      { 1 },
+      { 1, 2 },
+      { 1, 2, 3 },
+      { 1, 2, 3, 4 },
+      { { },               m_reserver },
+      { { 1 },             m_reserver },
+      { { 1, 2 },          m_reserver },
+      { { 1, 2, 3 },       m_reserver },
+      { { 1, 2, 3, 4 },    m_reserver },
+      { { 1, 2, 3, 4, 5 }, m_reserver },
+    };
+
+    for (std::size_t i = 0; i < ns.size (); ++i)
+      for (std::size_t j = 0; j < ms.size (); ++j)
+        check (ns[i], ms[j]);
+    return 0;
+  }
+
+  GCH_SMALL_VECTOR_TEST_CONSTEXPR
+  int
+  check_no_inline (void)
+  {
+    // Check vectors with no inline elements.
+    check<0, 0> ({ },      { });
+    check<0, 0> ({ 1 },    { });
+    check<0, 0> ({ 1, 2 }, { });
+    check<0, 0> ({ },      { 11 });
+    check<0, 0> ({ 1 },    { 11 });
+    check<0, 0> ({ 1, 2 }, { 11 });
+    check<0, 0> ({ },      { 11, 22 });
+    check<0, 0> ({ 1 },    { 11, 22 });
+    check<0, 0> ({ 1, 2 }, { 11, 22 });
+    return 0;
+  }
+
+  GCH_SMALL_VECTOR_TEST_CONSTEXPR
+  int
+  check_equal_inline (void)
   {
     // Check vectors with the same number of inline elements.
     // Let N = 2, and let both vectors have N inline elements.
@@ -57,12 +138,12 @@ private:
     //       N < K elements     (7)
     // (28 total cases).
 
-    auto reserver = [](vector_type<N>& v) {
+    auto reserver = [](vector_type<2>& v) {
       v.reserve (3);
     };
 
-    std::array<vector_init_type<N>, 8> ns {
-      vector_init_type<N> { },
+    std::array<vector_init_type<2>, 8> ns {
+      vector_init_type<2> { },
       { 1 },
       { 1, 2 },
       { { },      reserver },
@@ -72,8 +153,8 @@ private:
       { { 1, 2, 3, 4 } },
     };
 
-    std::array<vector_init_type<N>, 8> ms {
-      vector_init_type<N> { },
+    std::array<vector_init_type<2>, 8> ms {
+      vector_init_type<2> { },
       { 11 },
       { 11, 22 },
       { { },        reserver },
@@ -86,35 +167,48 @@ private:
     for (std::size_t i = 0; i < ns.size (); ++i)
       for (std::size_t j = i; j < ms.size (); ++j)
         check (ns[i], ms[j]);
+    return 0;
   }
 
-  template <unsigned N, typename U = T,
+
+  template <unsigned N, unsigned M, typename U = T,
             typename std::enable_if<std::is_base_of<gch::test_types::triggering_base, U>::value
             >::type * = nullptr>
   void
-  check (vector_init_type<N> ni, vector_init_type<N> mi)
+  check (vector_init_type<N> ni, vector_init_type<M> mi)
   {
     verify_basic_exception_safety (
-      [] (vector_type<N>& n, vector_type<N>& m) { n.swap (m); },
+      [] (vector_type<N>& n, vector_type<M>& m) { n.swap (m); },
+      ni,
+      mi,
+      m_lhs_alloc,
+      m_rhs_alloc);
+
+    verify_basic_exception_safety (
+      [] (vector_type<N>& n, vector_type<M>& m) { m.swap (n); },
       ni,
       mi,
       m_lhs_alloc,
       m_rhs_alloc);
   }
 
-  template <unsigned N, typename U = T,
+  template <unsigned N, unsigned M, typename U = T,
             typename std::enable_if<! std::is_base_of<gch::test_types::triggering_base, U>::value
             >::type * = nullptr>
   GCH_SMALL_VECTOR_TEST_CONSTEXPR
   void
-  check (vector_init_type<N> ni, vector_init_type<N> mi)
+  check (vector_init_type<N> ni, vector_init_type<M> mi)
   {
+    constexpr bool
+    propagate = std::allocator_traits<Allocator>::propagate_on_container_swap::value;
+
     vector_type<N> n_cmp (ni.begin (), ni.end (), m_lhs_alloc);
-    vector_type<N> m_cmp (mi.begin (), mi.end (), m_rhs_alloc);
-    {
+    vector_type<M> m_cmp (mi.begin (), mi.end (), m_rhs_alloc);
+
+    gch::test_types::verifying_allocator_base::with_scoped_context([&]() {
       // vector_type<N> (mi) -> vector_type<N> (ni)
       vector_type<N> n (ni.begin (), ni.end (), m_lhs_alloc);
-      vector_type<N> m (mi.begin (), mi.end (), m_rhs_alloc);
+      vector_type<M> m (mi.begin (), mi.end (), m_rhs_alloc);
 
       ni (n);
       mi (m);
@@ -124,11 +218,17 @@ private:
       CHECK (m == n_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (n.get_allocator ());
       gch::test_types::verify_not_created_by_container_copy_construction (m.get_allocator ());
-    }
-    {
+      if (m_lhs_alloc != m_rhs_alloc)
+      {
+        CHECK (propagate == (n.get_allocator () == m_rhs_alloc));
+        CHECK (propagate == (m.get_allocator () == m_lhs_alloc));
+      }
+    });
+
+    gch::test_types::verifying_allocator_base::with_scoped_context([&]() {
       // vector_type<N> (ni) -> vector_type<N> (mi)
       vector_type<N> n (ni.begin (), ni.end (), m_lhs_alloc);
-      vector_type<N> m (mi.begin (), mi.end (), m_rhs_alloc);
+      vector_type<M> m (mi.begin (), mi.end (), m_rhs_alloc);
 
       ni (n);
       mi (m);
@@ -138,7 +238,12 @@ private:
       CHECK (m == n_cmp);
       gch::test_types::verify_not_created_by_container_copy_construction (n.get_allocator ());
       gch::test_types::verify_not_created_by_container_copy_construction (m.get_allocator ());
-    }
+      if (m_lhs_alloc != m_rhs_alloc)
+      {
+        CHECK (propagate == (n.get_allocator () == m_rhs_alloc));
+        CHECK (propagate == (m.get_allocator () == m_lhs_alloc));
+      }
+    });
   }
 
   Allocator m_lhs_alloc;
@@ -149,18 +254,5 @@ GCH_SMALL_VECTOR_TEST_CONSTEXPR
 int
 test (void)
 {
-  using namespace gch::test_types;
-
-  test_with_allocator<tester, std::allocator> ();
-  test_with_allocator<tester, sized_allocator, std::uint8_t> ();
-  test_with_allocator<tester, fancy_pointer_allocator> ();
-  test_with_allocator<tester, allocator_with_id> ();
-  test_with_allocator<tester, propagating_allocator_with_id> ();
-
-#ifndef GCH_SMALL_VECTOR_TEST_HAS_CONSTEXPR
-  test_with_allocator<tester, verifying_allocator> ();
-  test_with_allocator<tester, non_propagating_verifying_allocator> ();
-#endif
-
-  return 0;
+  return test_with_allocators<tester> ();
 }


### PR DESCRIPTION
My attention was brought to this issue by Ilya Gorbatenko (Горбатенко Илья). Thanks Ilya!

An oversight which was made during development was the fact that construction of values should be done using the correct allocator during copy-assign, move-assign, and swap operations. This PR will fix that.

For example, during a move, if we have unequal allocators, and `propagate_on_container_move_assignment` is `true`, and if we need to construct elements in the inline buffer, then we need to make sure we construct those elements with the incoming allocator, rather than the existing one. This is a bit less trivial than it would seem because of the need to account for sound exception handling.

These changes still need a bit of cleanup, but should be correct, as verified by the improved rigor of the unit tests.