### PR TITLE
Fix allocator concept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 3.15)
 project (
   small_vector
   VERSION
-    0.10.1
+    0.10.2
   LANGUAGES
     CXX
 )

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import os
 class GchSmallVectorConan(ConanFile):
     name = "small_vector"
     author = "Gene Harvey <gharveymn@gmail.com>"
-    version = "0.10.1"
+    version = "0.10.2"
     license = "MIT"
     url = "https://github.com/gharveymn/small_vector"
     description = "A fully featured single header library implementing a vector container with a small buffer optimization."

--- a/source/bench/CMakeLists.txt
+++ b/source/bench/CMakeLists.txt
@@ -13,7 +13,7 @@ if (GCH_SMALL_VECTOR_BENCH_ENABLE_BOOST OR NOT DEFINED GCH_SMALL_VECTOR_BENCH_EN
   endfunction ()
 
   if (GCH_SMALL_VECTOR_BENCH_ENABLE_BOOST)
-    find_package (Boost REQUIRED COMPONENTS container)
+    find_package (Boost CONFIG REQUIRED COMPONENTS container)
 
     check_boost_header (HAVE_BOOST_SMALL_VECTOR_HPP)
 
@@ -21,7 +21,7 @@ if (GCH_SMALL_VECTOR_BENCH_ENABLE_BOOST OR NOT DEFINED GCH_SMALL_VECTOR_BENCH_EN
       message (FATAL_ERROR "Found Boost, but could not compile with boost/container/small_vector.hpp")
     endif ()
   else ()
-    find_package (Boost QUIET COMPONENTS container)
+    find_package (Boost CONFIG QUIET COMPONENTS container)
 
     if (Boost_FOUND)
       check_boost_header (HAVE_BOOST_SMALL_VECTOR_HPP QUIET)

--- a/source/include/gch/small_vector.hpp
+++ b/source/include/gch/small_vector.hpp
@@ -639,8 +639,10 @@ namespace gch
                    ||  requires { { a.destroy (xp) } -> std::convertible_to<void>; };
 
             /** Relationship between instances **/
-            requires NoThrowConstructibleFrom<A, decltype (b)>;
-            requires NoThrowConstructibleFrom<A, decltype (std::move (b))>;
+            { a1 == a2 } -> std::same_as<bool>;
+            { a1 != a2 } -> std::same_as<bool>;
+            requires ConstructibleFrom<A, decltype (b)>;
+            requires ConstructibleFrom<A, decltype (std::move (b))>;
 
             requires BoolConstant<typename std::allocator_traits<A>::is_always_equal>;
 
@@ -660,14 +662,6 @@ namespace gch
 
             requires BoolConstant<
               typename std::allocator_traits<A>::propagate_on_container_swap>;
-
-            { a == b } -> std::same_as<bool>;
-            { a != b } -> std::same_as<bool>;
-          }
-      &&  requires (A a1, A a2)
-          {
-            { a1 == a2 } -> std::same_as<bool>;
-            { a1 != a2 } -> std::same_as<bool>;
           };
 
     static_assert (AllocatorFor<std::allocator<int>, int>,

--- a/source/test/CMakeLists.txt
+++ b/source/test/CMakeLists.txt
@@ -168,4 +168,5 @@ endif ()
 
 add_custom_target (small_vector.ctest)
 
+add_subdirectory (integration)
 add_subdirectory (unit)

--- a/source/test/integration/CMakeLists.txt
+++ b/source/test/integration/CMakeLists.txt
@@ -1,0 +1,4 @@
+find_package (Boost CONFIG QUIET COMPONENTS interprocess)
+if (Boost_FOUND)
+  add_subdirectory (boost)
+endif ()

--- a/source/test/integration/boost/CMakeLists.txt
+++ b/source/test/integration/boost/CMakeLists.txt
@@ -1,0 +1,16 @@
+foreach (version ${GCH_SMALL_VECTOR_TEST_STANDARD_VERSIONS})
+  set (_TARGET_NAME small_vector.test.integration.boost.pmr_allocator.c++${version})
+  add_executable (${_TARGET_NAME} pmr_allocator.cpp)
+  target_link_libraries (${_TARGET_NAME} PRIVATE gch::small_vector Boost::boost)
+  target_compile_options (${_TARGET_NAME} PRIVATE "$<$<COMPILE_LANG_AND_ID:CXX,GNU>:-fconcepts-diagnostics-depth=100>")
+  set_target_properties (
+    ${_TARGET_NAME}
+    PROPERTIES
+    CXX_STANDARD
+      ${version}
+    CXX_STANDARD_REQUIRED
+      NO
+    CXX_EXTENSIONS
+      NO
+  )
+endforeach ()

--- a/source/test/integration/boost/pmr_allocator.cpp
+++ b/source/test/integration/boost/pmr_allocator.cpp
@@ -1,0 +1,34 @@
+#include <boost/interprocess/allocators/adaptive_pool.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <scoped_allocator>
+#include <gch/small_vector.hpp>
+#include <vector>
+
+namespace bi = boost::interprocess;
+using namespace gch;
+
+template<class T>
+using alloc = bi::adaptive_pool<T, bi::managed_shared_memory::segment_manager>;
+
+using ipc_row = small_vector<int, default_buffer_size<alloc<int>>::value, alloc<int>>;
+using scoped_alloc = std::scoped_allocator_adaptor<alloc<ipc_row>>;
+using ipc_matrix = small_vector<ipc_row, default_buffer_size<scoped_alloc>::value, scoped_alloc>;
+
+int main()
+{
+  bi::managed_shared_memory s(bi::create_only, "Demo", 65536);
+
+  // create vector of vectors in shared memory
+  ipc_matrix v(s.get_segment_manager());
+
+  // for all these additions, the inner vectors obtain their allocator arguments
+  // from the outer vector's scoped_allocator_adaptor
+  v.resize(1);
+  v[0].push_back(1);
+  v.emplace_back(2);
+//  std::vector<int> local_row = {1, 2, 3};
+  small_vector<int> local_row = {1, 2, 3};
+  v.emplace_back(local_row.begin(), local_row.end());
+
+  bi::shared_memory_object::remove("Demo");
+}


### PR DESCRIPTION
A few fixes for the Allocator concept, and other compilation errors which came up while writing an integration test using the PMR allocator combined with the Boost Interprocess shared memory manager.