### PR TITLE
Fix external swap requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,17 @@ namespace gch
                   )
               &&  InlineCapacity == 0
                )
+           
+    template <unsigned I>
+    constexpr
+    void
+    swap (small_vector& other)
+      requires (MoveInsertable && MoveAssignable && Swappable)
+           ||  (  (  std::is_same<std::allocator<value_type>, Allocator>::value
+                 ||  std::allocator_traits<Allocator>::propagate_on_container_swap::value
+                 ||  std::allocator_traits<Allocator>::is_always_equal::value
+                  )
+               )
 
     /* iteration */
     constexpr iterator               begin   (void)       noexcept;
@@ -677,6 +688,13 @@ namespace gch
   swap (small_vector<T, InlineCapacity, Allocator>& lhs,
         small_vector<T, InlineCapacity, Allocator>& rhs)
     noexcept (noexcept (lhs.swap (rhs)))
+    requires MoveInsertable && Swappable;
+  
+  template <typename T, unsigned InlineCapacityLHS, unsigned InlineCapacityRHS, typename Allocator>
+  constexpr
+  void
+  swap (small_vector<T, InlineCapacityLHS, Allocator>& lhs,
+        small_vector<T, InlineCapacityRHS, Allocator>& rhs)
     requires MoveInsertable && Swappable;
 
   template <typename T, unsigned InlineCapacity, typename Allocator, typename U>

--- a/source/include/gch/small_vector.hpp
+++ b/source/include/gch/small_vector.hpp
@@ -6297,13 +6297,14 @@ namespace gch
     noexcept (noexcept (lhs.swap (rhs)))
 #ifdef GCH_LIB_CONCEPTS
     requires concepts::MoveInsertable<T, small_vector<T, InlineCapacity, Allocator>, Allocator>
+          && concepts::MoveAssignable<T>
           && concepts::Swappable<T>
 #endif
   {
     lhs.swap (rhs);
   }
 
-  template <typename T, unsigned M, unsigned N, typename Allocator
+  template <typename T, unsigned InlineCapacityLHS, unsigned InlineCapacityRHS, typename Allocator
 #ifndef GCH_LIB_CONCEPTS
           , typename std::enable_if<std::is_move_constructible<T>::value
                                 &&  std::is_move_assignable<T>::value
@@ -6315,10 +6316,12 @@ namespace gch
             >
   inline GCH_CPP20_CONSTEXPR
   void
-  swap (small_vector<T, M, Allocator>& lhs, small_vector<T, N, Allocator>& rhs)
+  swap (small_vector<T, InlineCapacityLHS, Allocator>& lhs,
+        small_vector<T, InlineCapacityRHS, Allocator>& rhs)
     noexcept (noexcept (lhs.swap (rhs)))
 #ifdef GCH_LIB_CONCEPTS
-    requires concepts::MoveInsertable<T, small_vector<T, M, Allocator>, Allocator>
+    requires concepts::MoveInsertable<T, small_vector<T, InlineCapacityLHS, Allocator>, Allocator>
+          && concepts::MoveAssignable<T>
           && concepts::Swappable<T>
 #endif
   {


### PR DESCRIPTION
Recent changes added the requirement of `MoveAssignable` to `small_vector::swap`, but it was neglected to be added to the external one.

Also, adds documentation missing for the new unequal `InlineCapacity` variants.