### PR TITLE
Fix stdlib interop

### DIFF
--- a/source/include/gch/small_vector.hpp
+++ b/source/include/gch/small_vector.hpp
@@ -1726,9 +1726,7 @@ namespace gch
             ||  std::contiguous_iterator<InputIt>
 #endif
 #ifdef GCH_STDLIB_INTEROP
-            ||  std::is_same<InputIt, typename std::array<value_ty>::iterator>::value
-            ||  std::is_same<InputIt, typename std::array<value_ty>::const_iterator>::value
-            ||  (! std::is_same<value_ty, bool>
+            ||  (! std::is_same<value_ty, bool>::value
                &&  (  std::is_same<InputIt, typename std::vector<value_ty>::iterator>::value
                   ||  std::is_same<InputIt, typename std::vector<value_ty>::const_iterator>::value)
                 )

--- a/source/test/unit/member/assign/CMakeLists.txt
+++ b/source/test/unit/member/assign/CMakeLists.txt
@@ -5,3 +5,10 @@ add_small_vector_unit_tests (
   test-move.cpp
   test-range.cpp
 )
+
+add_small_vector_unit_tests (
+  test-interop.cpp
+  NO_CONSTEXPR
+  COMPILE_DEFINITIONS
+    GCH_STDLIB_INTEROP
+)

--- a/source/test/unit/member/assign/test-interop.cpp
+++ b/source/test/unit/member/assign/test-interop.cpp
@@ -1,0 +1,35 @@
+/** test-interop.cpp
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include "unit_test_common.hpp"
+
+#include <array>
+#include <valarray>
+#include <vector>
+
+GCH_SMALL_VECTOR_TEST_CONSTEXPR
+int
+test (void)
+{
+  std::vector<int> src_vec { 1, 2, 3, 4 };
+  gch::small_vector<int, 2> from_vec (src_vec.begin (), src_vec.end ());
+  CHECK (from_vec.size () == src_vec.size ());
+  CHECK (std::equal (src_vec.begin (), src_vec.end (), from_vec.begin ()));
+
+  std::array<int, 4> src_arr { 5, 6, 7, 8 };
+  gch::small_vector<int, 2> from_arr;
+  from_arr.assign (src_arr.begin (), src_arr.end ());
+  CHECK (from_arr.size () == src_arr.size ());
+  CHECK (std::equal (src_arr.begin (), src_arr.end (), from_arr.begin ()));
+
+  const std::valarray<int> src_val { 9, 10, 11, 12 };
+  gch::small_vector<int, 2> from_val;
+  from_val.assign (std::begin (src_val), std::end (src_val));
+  CHECK (from_val.size () == src_val.size ());
+  CHECK (std::equal (std::begin (src_val), std::end (src_val), from_val.begin ()));
+
+  return 0;
+}


### PR DESCRIPTION
Hi, thanks for writing and publishing this awesome container. It's my preferred implementation of a vector with inline capacity.

I noticed some issues with conditions gated behind `GCH_STDLIB_INTEROP` that prevent compilation when enabled. I decided to fix them and write a test to confirm. I hope this is useful, it was for me lol.

I didn't see any contribution guidelines, so I just tried to match the existing style and pointed my changes at `main`.

Let me know if you need any changes. I did run tests locally, but only for C++23.